### PR TITLE
Fixes argument for mounting volumes.

### DIFF
--- a/manuscripts/Dockerfile
+++ b/manuscripts/Dockerfile
@@ -15,7 +15,7 @@ CMD ["R", "-e", "rmarkdown::render('manuscript.Rmd')"]
 
 ## Equivalent to:
 ##  
-##     docker run --name rnexml --volumes $(pwd):/home/rstudio/rnexml \
+##     docker run --name rnexml --volume=$(pwd):/home/rstudio/rnexml \
 ##       --workdir /home/rstudio/rnexml --user docker rocker/ropensci \
 ##       R -e "rmarkdown::render('manuscript.Rmd')"
 ## 


### PR DESCRIPTION
Perhaps this is a difference between OSs or systems, but for me the
argument `--volumes` results in an error. It needs to be `--volume=`
for mounting host directories, at least on MacOSX.