### PR TITLE
Update dplyr dependency version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     reshape2 (>= 1.2.2),
     httr (>= 0.3),
     uuid (>= 0.1-1),
-    dplyr (>= 0.4.0),
+    dplyr (>= 0.5.0),
     lazyeval (>= 0.1.0),
     tidyr (>= 0.3.1),
     stringr (>= 1.0)


### PR DESCRIPTION
This is now dependent on at least the v0.5.0 version of `dplyr`, isn't it?