### PR TITLE
Patch polymorphic / uncertain state type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -80,7 +80,7 @@ Collate:
     'simmap.R'
     'taxize_nexml.R'
     'tbl_df.R'
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.0
 X-schema.org-applicationCategory: Data Publication
 X-schema.org-keywords: metadata, nexml, phylogenetics, linked-data
 X-schema.org-isPartOf: https://ropensci.org

--- a/R/character_classes.R
+++ b/R/character_classes.R
@@ -154,13 +154,13 @@ setAs("XMLInternalElementNode", "states",
 ####################################################### 
 ## technically symbol is positive integer http://nexml.org/doc/schema-1/characters/standard/#StandardToken
 setClass("state",
-         slots = c(symbol = "integer"), 
+         slots = c(symbol = "character"), 
          contains = "IDTagged")
 setMethod("fromNeXML", 
           signature("state", "XMLInternalElementNode"),
           function(obj, from){
             obj <- callNextMethod()
-            obj@symbol <- as.integer(xmlAttrs(from)["symbol"])
+            obj@symbol <- as.character(xmlAttrs(from)["symbol"])
             obj
           })
 setMethod("toNeXML", 

--- a/R/get_characters.R
+++ b/R/get_characters.R
@@ -96,7 +96,7 @@ get_characters <- function(nex, rownames_as_col=FALSE, otu_id = FALSE, otus_id =
     dplyr::distinct() %>%
     dplyr::mutate_(.dots = setNames(list(~cellclass(xsi.type)), "class"))
   
-  for(i in dim(type)[1])
+  for(i in seq_along(seq(1,dim(type)[1])))
     class(out[[type$label[i]]]) <- type$class[i]
   
   

--- a/man/add_characters.Rd
+++ b/man/add_characters.Rd
@@ -4,7 +4,8 @@
 \alias{add_characters}
 \title{Add character data to a nexml object}
 \usage{
-add_characters(x, nexml = new("nexml"), append_to_existing_otus = FALSE)
+add_characters(x, nexml = new("nexml"),
+  append_to_existing_otus = FALSE)
 }
 \arguments{
 \item{x}{character data, in which character traits labels are column names

--- a/man/add_meta.Rd
+++ b/man/add_meta.Rd
@@ -4,8 +4,8 @@
 \alias{add_meta}
 \title{Add metadata to a nexml file}
 \usage{
-add_meta(meta, nexml = new("nexml"), level = c("nexml", "otus", "trees",
-  "characters"), namespaces = NULL, i = 1, at_id = NULL)
+add_meta(meta, nexml = new("nexml"), level = c("nexml", "otus",
+  "trees", "characters"), namespaces = NULL, i = 1, at_id = NULL)
 }
 \arguments{
 \item{meta}{a meta S4 object, e.g. ouput of the function \code{\link{meta}}, or a list of these meta objects}

--- a/man/meta.Rd
+++ b/man/meta.Rd
@@ -4,9 +4,9 @@
 \alias{meta}
 \title{Constructor function for metadata nodes}
 \usage{
-meta(property = character(0), content = character(0), rel = character(0),
-  href = character(0), datatype = character(0), id = character(0),
-  type = character(0), children = list())
+meta(property = character(0), content = character(0),
+  rel = character(0), href = character(0), datatype = character(0),
+  id = character(0), type = character(0), children = list())
 }
 \arguments{
 \item{property}{specify the ontological definition together with it's namespace, e.g. dc:title}

--- a/man/nexml_add.Rd
+++ b/man/nexml_add.Rd
@@ -4,8 +4,8 @@
 \alias{nexml_add}
 \title{add elements to a new or existing nexml object}
 \usage{
-nexml_add(x, nexml = new("nexml"), type = c("trees", "characters", "meta",
-  "namespaces"), ...)
+nexml_add(x, nexml = new("nexml"), type = c("trees", "characters",
+  "meta", "namespaces"), ...)
 }
 \arguments{
 \item{x}{the object to be added}

--- a/man/nexml_figshare.Rd
+++ b/man/nexml_figshare.Rd
@@ -5,8 +5,9 @@
 \title{publish nexml to figshare}
 \usage{
 nexml_figshare(nexml, file = "nexml.xml",
-  categories = "Evolutionary Biology", tags = list("phylogeny", "NeXML"),
-  visibility = c("public", "private", "draft"), id = NULL, ...)
+  categories = "Evolutionary Biology", tags = list("phylogeny",
+  "NeXML"), visibility = c("public", "private", "draft"), id = NULL,
+  ...)
 }
 \arguments{
 \item{nexml}{a nexml object (or file path to a nexml file)}

--- a/man/nexml_get.Rd
+++ b/man/nexml_get.Rd
@@ -5,8 +5,9 @@
 \alias{get_item}
 \title{Get the desired element from the nexml object}
 \usage{
-nexml_get(nexml, element = c("trees", "trees_list", "flat_trees", "metadata",
-  "otu", "taxa", "characters", "characters_list", "namespaces"), ...)
+nexml_get(nexml, element = c("trees", "trees_list", "flat_trees",
+  "metadata", "otu", "taxa", "characters", "characters_list",
+  "namespaces"), ...)
 }
 \arguments{
 \item{nexml}{a nexml object (from read_nexml)}

--- a/tests/testthat/test_comp_analysis.R
+++ b/tests/testthat/test_comp_analysis.R
@@ -7,7 +7,7 @@ library(geiger)
 test_that("We can extract tree and trait data to run fitContinuous and fitDiscrete", {
   nexml <- read.nexml(system.file("examples", "comp_analysis.xml", package="RNeXML"))
   traits <- get_characters(nexml)
-  tree <- get_trees(nexml)
+  tree <- get_trees(nexml) 
   expect_is(tree, "phylo")
   cts <- fitContinuous(tree, traits[1], ncores=1)
   ## Incredibly, fitDiscrete cannot take discrete characters


### PR DESCRIPTION
@hlapp I think this should now fix #171 / #172, but please verify.  As mentioned in the commit note, this  is just a really small fix to a bug in the S4 class definition of `state`, which defined `symbol` as integer type for standard states (e.g. `symbol="1"`), but as character type for polymorphic states (e.g.  `symbol="1 or 0"`).  

Actually I believe this may actually be from what feels like an inconsistency in the NeXML schema.  
In a standard state it appears to me that `symbol` attribute on a state is technically typed as a [StandardToken](http://www.nexml.org/doc/schema-1/characters/standard/#StandardToken), which looks to me to be defined as a restriction of `xs:integer`, which is I think why I typed the symbol as integer in the first place. 

Meanwhile, in the NeXML schema defines `symbol` to be a `xs:string` in the case of a polymorphic state set, at least according to: http://www.nexml.org/doc/schema-1/characters/standard/#StandardUncertainStateSet

To me, this seems inconsistent, and is also the immediate cause of the bugs you identified, because R refuses to bind the integer symbol column to a character symbol column.  Declaring symbol to always be a character string as I've done in the PR resolves the issue, but technically appears to be a deviation from the types declared by the schema itself.  

cc'ing @rvosa for additional insight on this. 

