### PR TITLE
Fixes broken handling of polymorphic and uncertain states

### DIFF
--- a/tests/testthat/test_get_characters.R
+++ b/tests/testthat/test_get_characters.R
@@ -9,8 +9,19 @@ test_that("Getting characters", {
   
 })
 
-test_that("get_characters throws appropriate warnings", {
-  f <- system.file("examples", "comp_analysis.xml", package="RNeXML")
+test_that("get_characters can deal with polymorphic character states", {
+  f <- system.file("examples", "ontotrace-result.xml", package="RNeXML")
   nex <- read.nexml(f)
-  expect_is(get_characters(nex), "data.frame")
+  m <- get_characters(nex,
+                      rownames_as_col = TRUE,
+                      otu_id = TRUE,
+                      otus_id = TRUE)
+  expect_is(m, "data.frame")
+  expect_gt(ncol(m), 3)
+  expect_true(any(is.na(m[, 4])))
+  expect_false(all(is.na(m[, 4])))
+  expect_is(m[, 4], "integer")
+  expect_is(m[, ncol(m)], "character")
+  expect_false(any(is.na(m[, ncol(m)])))
+  expect_gt(max(nchar(m[, ncol(m)])), 1)
 })


### PR DESCRIPTION
This fixes the handling of polymorphic and uncertain character states for non-molecular (such as morphological) characters, as documented in #171 and #172.

The change does not include code for allowing the user to specify a custom symbol for polymorphic and uncertain states. The symbol in the returned matrix will simply be the one given for the respective state sets in the NeXML object.

Also includes a much expanded test.

Closes #171. Addresses much of #172 as well, except for giving the user control over the symbol being used, and enabling queries as to which cells are polymorphic.