### PR TITLE
 Makes test suite more robust, including to missing packages

### DIFF
--- a/tests/testthat/geiger_test.R
+++ b/tests/testthat/geiger_test.R
@@ -1,10 +1,11 @@
 context("Geiger tests (may take 15+ minutes)")
 
 
-library(geiger)
+has_geiger <- require(geiger)
 
 
 test_that("We can write caudata data to nexml", {
+  skip_if_not(has_geiger)
   data(caudata)
   nexml_write(trees = caudata$phy, characters = caudata$dat, file="tmp.xml")
   expect_true_or_null(nexml_validate("tmp.xml"))
@@ -13,6 +14,7 @@ test_that("We can write caudata data to nexml", {
 
 
 test_that("We can write geospiza data to nexml", {
+  skip_if_not(has_geiger)
   data(geospiza)
   nexml_write(trees = geospiza$phy, characters = geospiza$dat, file="tmp.xml")
   expect_true_or_null(nexml_validate("tmp.xml"))
@@ -20,6 +22,7 @@ test_that("We can write geospiza data to nexml", {
 })
 
 test_that("We can write chelonia data to nexml", {
+  skip_if_not(has_geiger)
   data(chelonia)
   nexml_write(trees = chelonia$phy, characters = chelonia$dat, file="tmp.xml")
   expect_true_or_null(nexml_validate("tmp.xml"))
@@ -27,6 +30,7 @@ test_that("We can write chelonia data to nexml", {
 })
 
 test_that("We can write primates data to nexml", {
+  skip_if_not(has_geiger)
   data(primates)
   nexml_write(trees = primates$phy, characters = primates$dat, file="tmp.xml")
   expect_true_or_null(nexml_validate("tmp.xml"))
@@ -34,6 +38,7 @@ test_that("We can write primates data to nexml", {
 })
 
 test_that("We can write whales data to nexml", {
+  skip_if_not(has_geiger)
   data(whales)
 # taxa need to be rownames not separate column 
   whales$dat <- whales$richness[[2]]
@@ -46,6 +51,7 @@ test_that("We can write whales data to nexml", {
 
 test_that("We can write amphibia multiphylo to nexml. Two of these phylogenies each have nearly 3K taxa, so this may take around 12 minutes", {
 # multiphylo, where two phylogenies have each nearly 3K taxa
+  skip_if_not(has_geiger)
   data(amphibia)
   class(amphibia) <- "multiPhylo"
   runtime <- system.time(nexml_write(amphibia, file="tmp.xml")) # Slow! about 12 minutes

--- a/tests/testthat/test_characters.R
+++ b/tests/testthat/test_characters.R
@@ -36,18 +36,17 @@ test_that("we can actually parse NeXML files containing character data", {
   expect_is(nex, "nexml")
 })
 
-
-## Now that we tested this, store the result so we can use it in later tests 
+## Now that we tested this, store the result so we can use it in later tests
 nex <- read.nexml(f)
+
+### BEGIN *DO NOT MODIFY nex OBJECT* ###
+###                                  ###
 
 test_that("we can extract character matrix with get_characters", {
   x <- get_characters(nex)
   expect_is(x, "data.frame")
 ## FIXME add additional and more precise expect_ checks 
 })
-
-
-
 
 test_that("we can extract a list of character matrices with get_characters_list", {
   x <- get_characters_list(nex)
@@ -57,34 +56,10 @@ test_that("we can extract a list of character matrices with get_characters_list"
 
 })
 
-
-## 
-test_that("add_otu can append only unmatched taxa to an existing otus block", {
-  orig <- get_taxa(nex)
-  x <- get_characters_list(nex)
-  nex@otus[[1]]@otu <- new("ListOfotu", nex@otus[[1]]@otu[1:5]) # chop off some of the otu values
-
-  new_taxa <- rownames(x[[1]]) 
-  nex2 <- RNeXML:::add_otu(nex, new_taxa, append=TRUE) # add them back 
-## should have same contents as orig... 
-  get_taxa(nex2)
-  expect_identical(sort(orig$label), sort(get_taxa(nex2)$label))
-
-## Note that otu ids are not unique when we chop them off ...
-})
-
-
-
-
-
 ## FIXME add_characters needs a method to add character names of states
 ## and then we need a test for that method
 
-
 test_that("we can add characters to a nexml file using a data.frame", {
-  f <- system.file("examples", "comp_analysis.xml", package="RNeXML")
-  
-  nex <- read.nexml(f)
   x <- get_characters(nex)
   nexml <- add_characters(x)
 
@@ -98,16 +73,33 @@ test_that("we can add characters to a nexml file using a data.frame", {
   unlink("chartest.xml")
 })
 
-
-
-
 ## based on bug on 2014-03-12 65ae459523c529452adb699c3d5d118c0a207402 
 test_that("we can add multiple character matrices to a nexml file", {
           skip_if_not(require(geiger))
           data(geospiza)
           data(primates)
-          nex <- add_characters(geospiza$dat)
-          nex <- add_characters(primates$dat, nex)
-          expect_is(nex, "nexml")
+          nexml <- add_characters(geospiza$dat)
+          nexml <- add_characters(primates$dat, nexml)
+          expect_is(nexml, "nexml")
 })
 
+###                                  ###
+### END *DO NOT MODIFY nex OBJECT*   ###
+###                                  ###
+### Re-read nex object before using  ###
+###                                  ###
+
+test_that("add_otu can append only unmatched taxa to an existing otus block", {
+  nex <- read.nexml(f)
+  orig <- get_taxa(nex)
+  x <- get_characters_list(nex)
+  nex@otus[[1]]@otu <- new("ListOfotu", nex@otus[[1]]@otu[1:5]) # chop off some of the otu values
+
+  new_taxa <- rownames(x[[1]])
+  nex2 <- RNeXML:::add_otu(nex, new_taxa, append=TRUE) # add them back
+  ## should have same contents as orig...
+  get_taxa(nex2)
+  expect_identical(sort(orig$label), sort(get_taxa(nex2)$label))
+
+  ## Note that otu ids are not unique when we chop them off ...
+})

--- a/tests/testthat/test_characters.R
+++ b/tests/testthat/test_characters.R
@@ -103,7 +103,7 @@ test_that("we can add characters to a nexml file using a data.frame", {
 
 ## based on bug on 2014-03-12 65ae459523c529452adb699c3d5d118c0a207402 
 test_that("we can add multiple character matrices to a nexml file", {
-          library("geiger")
+          skip_if_not(require(geiger))
           data(geospiza)
           data(primates)
           nex <- add_characters(geospiza$dat)

--- a/tests/testthat/test_comp_analysis.R
+++ b/tests/testthat/test_comp_analysis.R
@@ -1,10 +1,9 @@
 context("Comparative analysis")
 
-
-library(geiger)
-
+has_geiger <- require(geiger)
 
 test_that("We can extract tree and trait data to run fitContinuous and fitDiscrete", {
+  skip_if_not(has_geiger)
   nexml <- read.nexml(system.file("examples", "comp_analysis.xml", package="RNeXML"))
   traits <- get_characters(nexml)
   tree <- get_trees(nexml)
@@ -19,6 +18,7 @@ test_that("We can extract tree and trait data to run fitContinuous and fitDiscre
 
 
 test_that("We can serialize tree and trait data for a comparative analysis", {
+  skip_if_not(has_geiger)
   data(geospiza)
   add_trees(geospiza$phy)
   nexml <- add_characters(geospiza$dat)

--- a/tests/testthat/test_nexml_read.R
+++ b/tests/testthat/test_nexml_read.R
@@ -26,21 +26,19 @@ test_that("we can read nexml from a character string of xml", {
 })
 
 test_that("we can read nexml from a XMLInternalDocument object", {
-  library("httr")
   library("XML")
-  x <- xmlParse(content(GET(url)))
+  x <- xmlParse(f)
   nex <- nexml_read(x)
-  
+
   expect_is(nex, "nexml")
   expect_equal(nex@trees@names, "trees")
 })
 
 test_that("we can read nexml from a XMLInternalNode object", {
-  library("httr")
   library("XML")
-  x <- xmlParse(content(GET(url)))
+  x <- xmlParse(f)
   nex <- nexml_read(xmlRoot(x))
-  
+
   expect_is(nex, "nexml")
   expect_equal(nex@trees@names, "trees")
 })

--- a/tests/testthat/test_rdf.R
+++ b/tests/testthat/test_rdf.R
@@ -19,9 +19,9 @@ test_that("we can extract rdf-xml", {
 })
 
 test_that("we can perform sparql queries with rdf", {
-  skip_on_travis()
   skip_if_not(require(rdflib))
   skip_if_not_installed("xslt")
+  # skip_on_travis()
   skip_on_os("solaris")
   
   rdf <- get_rdf(system.file("examples/primates.xml", package="RNeXML"))

--- a/tests/testthat/test_rdf.R
+++ b/tests/testthat/test_rdf.R
@@ -1,10 +1,9 @@
 context("rdf")
 
-has_rdf <- require(rdflib)
-
 test_that("we can extract rdf-xml", {
 
-  skip_if_not(has_rdf)
+  skip_if_not(require(rdflib))
+  skip_if_not_installed("xslt")
   skip_on_os("solaris")
   
   rdf <- get_rdf(system.file("examples/primates.xml", package="RNeXML"))
@@ -21,6 +20,8 @@ test_that("we can extract rdf-xml", {
 
 test_that("we can perform sparql queries with rdf", {
   skip_on_travis()
+  skip_if_not(require(rdflib))
+  skip_if_not_installed("xslt")
   skip_on_os("solaris")
   
   rdf <- get_rdf(system.file("examples/primates.xml", package="RNeXML"))

--- a/tests/testthat/test_simmap.R
+++ b/tests/testthat/test_simmap.R
@@ -8,7 +8,7 @@ context("simmap")
 test_that("we can coerce an ape::phylo tree with a 
           phytools:simmap extension into nexml", {
   skip_if_not_installed("phytools")
-  library("phytools")
+  require("phytools")
   set.seed(10) 
   tree <- rbdtree(b = log(50), d = 0, Tmax = .5)
   Q <- matrix(c(-2, 1, 1, 1, -2 ,1 ,1, 1, -2), 3, 3) 
@@ -35,6 +35,3 @@ test_that("we can coerce an ape::phylo tree with a
   # checks that we got the states slot correct 
   expect_equal(converted, orig)
 })
-
-
-


### PR DESCRIPTION
There are a number of tests that depend on packages in the suggested category, and which are arguably needed by very few only. The changes here will skip those tests rather than fail hard.

Also fixes some test cases that were overriding a global object (which happened to be inconsequential because that test case was at the end), and re-enables a test on Travis that wasn't being run there.