### PR TITLE
Fixes type coercion for morphological characters with polymorphic states

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,6 +79,7 @@ Collate:
     'simmap.R'
     'taxize_nexml.R'
     'tbl_df.R'
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.0
 X-schema.org-applicationCategory: Data Publication
 X-schema.org-keywords: metadata, nexml, phylogenetics, linked-data

--- a/man/get_characters.Rd
+++ b/man/get_characters.Rd
@@ -5,7 +5,7 @@
 \title{Get character data.frame from nexml}
 \usage{
 get_characters(nex, rownames_as_col = FALSE, otu_id = FALSE,
-  otus_id = FALSE)
+  otus_id = FALSE, include_state_types = FALSE)
 }
 \arguments{
 \item{nex}{a nexml object}
@@ -18,9 +18,15 @@ otu id (for joining with otu metadata, etc)}
 
 \item{otus_id}{logical, default FALSE. return a column with the 
 otus block id (for joining with otu metadata, etc)}
+
+\item{include_state_types}{logical, default FALSE. whether to also return a 
+matrix of state types (with values standard, polymorphic, and uncertain)}
 }
 \value{
-the character matrix as a data.frame
+the character matrix as a data.frame, or if `include_state_types is
+ TRUE a list of two elements, `characters` as the character matrix, and
+ state_types as a matrix of state types. Both matrices will be in the same
+ ordering of rows and columns.
 }
 \description{
 Get character data.frame from nexml


### PR DESCRIPTION
The algorithm implemented here keeps the previous mechanism for column type coercion, however it is now only applied for characters that don't have a polymorpic or uncertain state.

Accomplishing this without depending on correctly second-guessing the symbol requires knowing for each state whether it is polymorphic, uncertain, or "standard". To not have do this work again if the user wants to have this knowledge as well, we return this on demand in the form of a second matrix whose columns are factors with levels `standard`, `polymorphic`, and `uncertain`. The matrix will have `NA` where the state is `NA`.

Fixes #186. Closes #175.