### PR TITLE
Fix serialization of polymorphic and uncertain states

### DIFF
--- a/R/character_classes.R
+++ b/R/character_classes.R
@@ -137,8 +137,12 @@ setMethod("fromNeXML",
 setMethod("toNeXML", 
           signature("states", "XMLInternalElementNode"),
           function(object, parent){
+            suppressWarnings({ # avoid arcane XML warning message
             parent <- callNextMethod()
             addChildren(parent, kids = object@state)
+            addChildren(parent, kids = object@uncertain_state_set)
+            addChildren(parent, kids = object@polymorphic_state_set)
+            })
             parent
           })
 setAs("states", "XMLInternalNode",

--- a/tests/testthat/test_characters.R
+++ b/tests/testthat/test_characters.R
@@ -103,3 +103,16 @@ test_that("add_otu can append only unmatched taxa to an existing otus block", {
 
   ## Note that otu ids are not unique when we chop them off ...
 })
+
+
+test_that("we can serialize polymorphic states", {
+  
+  f <- system.file("examples", "ontotrace-result.xml", package="RNeXML")
+  nex <- read.nexml(f)
+  states <- nex@characters[[1]]@format@states[[1]]
+  out <- as(states, "XMLInternalNode")
+  testthat::expect_true("polymorphic_state_set" %in% names(out))
+  
+})
+
+


### PR DESCRIPTION
toNeXML method for "states" set mistakenly omitted `uncertain_state_set` and `polymorphic_state_set` children.  Patch includes test. Patch for #191.

 cc @hlapp 