### PR TITLE
Adds description of changes for next release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RNeXML
 Type: Package
 Title: Semantically Rich I/O for the 'NeXML' Format
-Version: 2.1.2.99
+Version: 2.2.0
 Authors@R: c(person("Carl", "Boettiger", role = c("cre", "aut"),
     email="cboettig@gmail.com", comment = c(ORCID="0000-0002-1642-628X")), 
     person("Scott", "Chamberlain", role ="aut", comment = c(ORCID="0000-0003-1444-9135")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,20 @@ For more fine-grained list of changes or to report a bug, consult
 * [The issues log](https://github.com/ropensci/RNeXML/issues)
 * [The commit log](https://github.com/ropensci/RNeXML/commits/master)
 
+v2.1.3
+------
+
+- Fixes various (previously broken) aspects of handling polymorphic
+  and uncertain states for discrete (non-molecular) and continuous
+  characters, including obtaining a character matrix (#174), ensuring
+  proper column types (#188), and serializing to NeXML (#192).
+- Adds the optional ability to, in addition to the character matrix,
+  obtain a concordantly formatted matrix of state types (standard,
+  polymorphic, uncertain).
+- Fixes loss of certain literal-valued metadata when serializing to
+  NeXML. #193
+- Drops package phylobase as dependency. (Also removes circular
+  dependency chain, because phylobase depends on RNeXML.)
 
 v2.1.2
 ------

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ For more fine-grained list of changes or to report a bug, consult
 * [The issues log](https://github.com/ropensci/RNeXML/issues)
 * [The commit log](https://github.com/ropensci/RNeXML/commits/master)
 
-v2.1.3
+v2.2.0
 ------
 
 - Fixes various (previously broken) aspects of handling polymorphic


### PR DESCRIPTION
Also, it seems that instead of incrementing to v2.1.3, which I had been assuming so far by default, we should increment to v2.2.0, given that at least one method changed it's API (even if not in a backwards-incompatible manner).

Part of addressing #185.