### PR TITLE
Fix blank node behavior of nested meta elements

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^CRAN-RELEASE$
 ^\.travis\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/R/classes.R
+++ b/R/classes.R
@@ -120,7 +120,10 @@ setMethod("fromNeXML",
               obj@id <- attrs[["id"]]
             if(!is.na(attrs[["rel"]]))
                  obj@rel <- attrs[["rel"]]
-               obj
+            kids <- xmlChildren(from)
+            if(length(kids) > 0)
+              obj@children <- lapply(kids[names(kids) == "meta"], as, "meta")
+            obj
           }
 )
 setMethod("toNeXML", 
@@ -132,6 +135,9 @@ setMethod("toNeXML",
                        rel = unname(object@rel))  
             attrs <- plyr::compact(attrs)
             addAttributes(parent, .attrs = attrs)
+            if (length(object@children) > 0)
+              addChildren(parent, kids = object@children)
+            parent
 })
 setAs("XMLInternalElementNode", "ResourceMeta", function(from) fromNeXML(new("ResourceMeta"), from)) 
 setAs("ResourceMeta", "XMLInternalElementNode", function(from) toNeXML(from, newXMLNode("meta")))

--- a/R/classes.R
+++ b/R/classes.R
@@ -114,7 +114,7 @@ setMethod("fromNeXML",
           function(obj, from){
             obj <- callNextMethod()
             attrs <- xmlAttrs(from)
-            if(!is.na(attrs["id"])) 
+            if(!is.na(attrs["href"]))
               obj@href <- attrs[["href"]]
             if(!is.na(attrs["id"]))
               obj@id <- attrs[["id"]]

--- a/R/classes.R
+++ b/R/classes.R
@@ -114,7 +114,8 @@ setMethod("fromNeXML",
           function(obj, from){
             obj <- callNextMethod()
             attrs <- xmlAttrs(from)
-            obj@href <- attrs[["href"]]
+            if(!is.na(attrs["id"])) 
+              obj@href <- attrs[["href"]]
             if(!is.na(attrs["id"]))
               obj@id <- attrs[["id"]]
             if(!is.na(attrs[["rel"]]))

--- a/inst/examples/meta_example.xml
+++ b/inst/examples/meta_example.xml
@@ -5,6 +5,11 @@
   <meta xsi:type="LiteralMeta" property="dc:date" datatype="xsd:string" content="2012-04-01"/>
   <meta xsi:type="ResourceMeta" href="http://creativecommons.org/publicdomain/zero/1.0/" rel="cc:license"/>
   <meta xsi:type="LiteralMeta" property="dc:publisher" datatype="xsd:string" content="unpublished data"/>
+  <meta xsi:type="ResourceMeta" rel="dc:source">
+    <meta xsi:type="LiteralMeta" property="dc:identifier">https://doi.org/10.1643/CI-08-076</meta>
+    <meta xsi:type="LiteralMeta" property="dc:bibliographicCitation">Lucinda, P. H. F. and R. P. Vari. 2009. New Steindachnerina species (Teleostei: Characiformes: Curimatidae) from the Rio Tocantins basin. Copeia, 2009(1):142-147</meta>
+    <meta xsi:type="LiteralMeta" property="dc:title">Lucinda and Vari (2009)</meta>
+  </meta> 
   <otus id="tax1">
     <otu label="Struthioniformes" id="t1"/>
     <otu label="Tinamiformes" id="t2"/>

--- a/tests/testthat/test_meta.R
+++ b/tests/testthat/test_meta.R
@@ -129,3 +129,16 @@ test_that("we can write numeric types of meta elements and get correct datatype"
           expect_is(m@content, "character")
           expect_match(m@datatype, ".*:decimal")
 })
+
+test_that("we can serialize nested meta elements", {
+
+  f <- system.file("examples", "meta_example.xml", package="RNeXML")
+  nex <- read.nexml(f)
+  s <- nex@meta[sapply(nex@meta,
+                       function(x)
+                         ("rel" %in% slotNames(x)) &&
+                         (x@rel == "dc:source"))]
+  out <- as(s$meta, "XMLInternalNode")
+  out_m <- sapply(xmlChildren(out), xmlAttrs)
+  testthat::expect_equal(dim(out_m), c(3, 3))
+})

--- a/tests/testthat/test_meta_extract.R
+++ b/tests/testthat/test_meta_extract.R
@@ -45,7 +45,11 @@ test_that("we can correctly parse ResourceMeta annotations", {
 })
 
 test_that("we can parse nested meta with blank nodes", {
-  
+
+  skip_if_not(require(rdflib))
+  skip_if_not_installed("xslt")
+  skip_on_os("solaris")
+
   f <- system.file("examples", "meta_example.xml", package="RNeXML")
   nex <- read.nexml(f)
   tmp <- tempfile()

--- a/tests/testthat/test_meta_extract.R
+++ b/tests/testthat/test_meta_extract.R
@@ -42,6 +42,10 @@ test_that("we can correctly parse ResourceMeta annotations", {
   meta <- get_metadata(nex)
   lic <- dplyr::filter(meta, (rel == "cc:license") | (property == "cc:license"))$href
   testthat::expect_equal(lic, "http://creativecommons.org/publicdomain/zero/1.0/")
+  meta <- cbind(meta, nkids = sapply(nex@meta, function(x) length(x@children)))
+  rmeta <- dplyr::filter(meta, xsi.type == "ResourceMeta")
+  testthat::expect_true(all(xor(is.na(rmeta[,"href"]), rmeta[,"nkids"] == 0)))
+  testthat::expect_gt(max(rmeta[,"nkids"]), 0)
 })
 
 test_that("we can parse nested meta with blank nodes", {

--- a/tests/testthat/test_meta_extract.R
+++ b/tests/testthat/test_meta_extract.R
@@ -35,6 +35,15 @@ test_that("we can parse literal meta nodes with literal node content", {
   testthat::expect_true(matches > 0)
   
 })
+
+test_that("we can correctly parse ResourceMeta annotations", {
+  f <- system.file("examples", "meta_example.xml", package="RNeXML")
+  nex <- read.nexml(f)
+  meta <- get_metadata(nex)
+  lic <- dplyr::filter(meta, (rel == "cc:license") | (property == "cc:license"))$href
+  testthat::expect_equal(lic, "http://creativecommons.org/publicdomain/zero/1.0/")
+})
+
 test_that("we can parse nested meta with blank nodes", {
   
   f <- system.file("examples", "meta_example.xml", package="RNeXML")

--- a/tests/testthat/test_meta_extract.R
+++ b/tests/testthat/test_meta_extract.R
@@ -35,4 +35,19 @@ test_that("we can parse literal meta nodes with literal node content", {
   testthat::expect_true(matches > 0)
   
 })
+test_that("we can parse nested meta with blank nodes", {
+  
+  f <- system.file("examples", "meta_example.xml", package="RNeXML")
+  nex <- read.nexml(f)
+  tmp <- tempfile()
+  xml2::write_xml(RNeXML::get_rdf(f), tmp)
+  triples <- rdflib::rdf_parse(tmp)
+  ## Check the blank node
+  df <- rdflib::rdf_query(triples, 
+  "SELECT ?s ?p ?o WHERE 
+   { ?s <http://purl.org/dc/elements/1.1/source> ?source .
+     ?source ?p ?o
+   }")
+  testthat::expect_equal(dim(df), c(3,3))
+})
 


### PR DESCRIPTION
Includes test using SPARQL query to verify blank node behavior.

@hlapp Sorry I got a bit confused about this one last night, too little sleep.  Anyway, thanks for reporting and I think this should resolve the issue.  Check out the added unit test for a quick demo parsing the nested meta as RDF and querying to illustrate that we do get a blank node. 

Fixes #196.