### PR TITLE
Fixes several bugs in handling metadata

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -189,7 +189,7 @@ setAs("meta", "XMLInternalElementNode", function(from){
         }
       else
         m <- from
-      toNeXML(m, newXMLNode("meta", .children = from@children))
+      toNeXML(m, newXMLNode("meta"))
 })
 setAs("meta", "XMLInternalNode", function(from) 
       as(from, "XMLInternalElementNode"))

--- a/R/classes.R
+++ b/R/classes.R
@@ -157,7 +157,7 @@ setMethod("toNeXML",
             attrs <- plyr::compact(attrs)
             addAttributes(parent, .attrs = attrs)
             if (length(object@children) > 0)
-              addChildren(parent, kids = object@children)
+              addChildren(parent, kids = lapply(object@children, as, "XMLInternalNode"))
             parent
 })
 setAs("XMLInternalElementNode", "ResourceMeta", function(from) fromNeXML(new("ResourceMeta"), from)) 

--- a/R/get_level.R
+++ b/R/get_level.R
@@ -84,6 +84,7 @@ nodelist_to_df <- function(node, element, fn, nodeId=NA){
         nested <- mapply(function(n, id) nodelist_to_df(n, "children", fn, id),
                          n = nodelist,
                          id = mout[,"Meta"])
+        if (is.null(names(nested))) nested <- as.data.frame(nested[,1])
         out <- dplyr::bind_rows(mout, nested)
       }
     }


### PR DESCRIPTION
In particular this applies to `meta()`-generated meta element, and more deeply nested meta elements (such as those generated by simmap).

This will need to be rebased into #201, but the issues being corrected have nothing to do with the prefixing of class names undertaken there, so I decided to put them against master first.