### PR TITLE
Reconfigures manuscript on CircleCI to run only on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,13 @@ jobs:
       - checkout
       - run: R -e "devtools::install(dep=T); rmarkdown::render('manuscripts/manuscript.Rmd')"
 
+workflows:
+  version: 2
+
+  build_only:
+    jobs:
+      - build:
+        filters:
+          branches:
+            only: master
 


### PR DESCRIPTION
See #211. In a nutshell, the free CircleCI account under which this is running has a cap on CPU time that resets every month (I believe). This means that builds that aren't well justified should not be undertaken, so that CPU time remains when it is well (or at least better) justified.

Since we meanwhile have a more extensive test suite, it is hard to imagine that between the tests and the vignettes there is anything that these would miss but that the manuscript (which isn't very thorough in what of the API it is touching) would catch. Hence, rebuild only on master.

Closes #211.