### PR TITLE
Reconfigures codecov success thresholds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,15 @@
 comment: false
+
+coverage:
+  round: up
+  precision: 1
+
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 2%
+        only_pulls: true


### PR DESCRIPTION
The main goal here is to reduce noise from insignificant drops. This will allow a drop of 1% for the project status, and 2% for the patch. We also change rounding to up, meaning that drops of more than 1% and 2%, respectively, will result in failure.

Finally, this is (in my understanding) disabling patch status outside of pull requests, which I think is most reasonable.