### PR TITLE
Enables handling of files with rootedge

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -357,11 +357,10 @@ setMethod("toNeXML",
           signature("edge", "XMLInternalElementNode"),
           function(object, parent){
             parent <- callNextMethod()
-            if(length(object@source) > 0)
-              addAttributes(parent, "source" = object@source)
-            else
-              # should signify the rootedge
+            if(is(object, "rootEdge"))
               xmlName(parent) <- "rootedge"
+            else
+              addAttributes(parent, "source" = object@source)
             addAttributes(parent, "target" = object@target)
             if(length(object@length) > 0)
                addAttributes(parent, "length" = object@length)
@@ -374,6 +373,16 @@ setAs("edge", "XMLInternalElementNode",
 setAs("XMLInternalElementNode", "edge",
       function(from) fromNeXML(nexml.edge(), from))
 
+# virtual class, allows asking is(edge, "rootEdge") to determine whether
+# a given edge object is a root edge or not
+setClass("rootEdge") # creates a virtual class
+setIs("edge", "rootEdge",
+      test = function(Object) {
+        length(Object@target) > 0 && length(Object@source) == 0
+      },
+      replace = function(Object, value) {
+        stop("rootEdge is virtual, cannot replace")
+      })
 
 ################################ alternatively called "Taxon" by the schema
 
@@ -490,7 +499,7 @@ setMethod("toNeXML",
             parent <- callNextMethod()
             addChildren(parent, kids = lcapply(object@node, as, "XMLInternalNode"))
             addChildren(parent, kids = lcapply(object@edge, as, "XMLInternalNode"))
-            if (length(object@rootedge@target) > 0)
+            if (is(object@rootedge, "rootEdge"))
               addChildren(parent, as(object@rootedge, "XMLInternalNode"))
             parent
           })

--- a/R/get_trees.R
+++ b/R/get_trees.R
@@ -134,7 +134,14 @@ toPhylo <- function(tree, otus){
                   function(x) 
                     c(node = unname(x@id), 
                       otu = missing_as_na(x@otu)))
-  
+  # conversion (nor ape?) can't handle rootedge, to if there is one, add source
+  if (length(tree@rootedge@target) > 0) {
+    rootEdge <- tree@rootedge
+    rootEdge@source <- nexml_id(prefix = "rn")
+    newroot <- c(node = rootEdge@source, otu = NA)
+    nodes <- cbind(unname(newroot), nodes)
+  } else
+    rootEdge <- NULL
   # If any edges have lengths, use this routine
   if(any(sapply(tree@edge, function(x) length(x@length) > 0)))
     edges <- sapply(unname(tree@edge), 
@@ -152,6 +159,14 @@ toPhylo <- function(tree, otus){
                       c(source = unname(x@source), 
                         target = unname(x@target), 
                         id = unname(x@id)))
+  # conversion (nor ape?) can't handle rootedge, to if there is one, add it
+  if (! is.null(rootEdge)) {
+    edges <- cbind(c(source = unname(rootEdge@source),
+                     target = unname(rootEdge@target),
+                     length = unname(rootEdge@length),
+                     id = unname(rootEdge@id)),
+                   edges)
+  }
 
   nodes <- data.frame(t(nodes), stringsAsFactors=FALSE)
   names(nodes) <- c("node", "otu")
@@ -182,9 +197,8 @@ toPhylo <- function(tree, otus){
   tip_otus <- as.character(na.omit(nodes$otu))   
   tip.label <- otus[tip_otus]
 
-  # Count internal nodes (assumes bifurcating tree. Does ape always assume this?) 
-  # FIXME use a method that does not assume bifurcating tree... 
-  Nnode <- length(tip.label) - 1 
+  # Count internal nodes
+  Nnode <- max(edge) - length(tip.label)
 
   # assemble the phylo object, assign class and return.  
   phy = list(edge=edge, 

--- a/R/get_trees.R
+++ b/R/get_trees.R
@@ -135,7 +135,7 @@ toPhylo <- function(tree, otus){
                     c(node = unname(x@id), 
                       otu = missing_as_na(x@otu)))
   # conversion (nor ape?) can't handle rootedge, to if there is one, add source
-  if (length(tree@rootedge@target) > 0) {
+  if (is(tree@rootedge, "rootEdge")) {
     rootEdge <- tree@rootedge
     rootEdge@source <- nexml_id(prefix = "rn")
     newroot <- c(node = rootEdge@source, otu = NA)

--- a/inst/examples/coal.xml
+++ b/inst/examples/coal.xml
@@ -1,0 +1,28 @@
+<nex:nexml xmlns:nex="http://www.nexml.org/2009" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdao="http://purl.obolibrary.org/obo/cdao.owl" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:ter="http://purl.org/dc/terms/" xmlns:prism="http://prismstandard.org/namespaces/1.2/basic/" xmlns:cc="http://creativecommons.org/ns#" xmlns:ncbi="http://www.ncbi.nlm.nih.gov/taxonomy#" xmlns:tc="http://rs.tdwg.org/ontology/voc/TaxonConcept#" xmlns="http://www.nexml.org/2009" version="0.9" generator="RNeXML">
+  <meta xsi:type="LiteralMeta" id="m5" property="dc:creator" datatype="xsd:string" content="lapp"/>
+  <meta xsi:type="ResourceMeta" id="m6" href="http://creativecommons.org/publicdomain/zero/1.0/" rel="cc:license"/>
+  <otus about="#os6" id="os6">
+    <otu about="#ou24" label="t2" id="ou24"/>
+    <otu about="#ou25" label="t1" id="ou25"/>
+    <otu about="#ou26" label="t4" id="ou26"/>
+    <otu about="#ou27" label="t5" id="ou27"/>
+  </otus>
+  <trees about="#ts6" id="ts6" otus="os6">
+    <tree xsi:type="FloatTree" about="#tree6" id="tree6">
+      <node about="#n49" id="n49"/>
+      <node about="#n50" id="n50"/>
+      <node about="#n51" id="n51"/>
+      <node about="#n52" id="n52" otu="ou24"/>
+      <node about="#n53" id="n53" otu="ou25"/>
+      <node about="#n54" id="n54" otu="ou26"/>
+      <node about="#n55" id="n55" otu="ou27"/>
+      <rootedge about="#e42" id="e42" target="n49" length="0.083950881"/>
+      <edge about="#e44" id="e44" source="n49" target="n50" length="0.5249018229"/>
+      <edge about="#e45" id="e45" source="n50" target="n52" length="0.04688745774"/>
+      <edge about="#e46" id="e46" source="n50" target="n53" length="0.04688745774"/>
+      <edge about="#e47" id="e47" source="n49" target="n51" length="0.4327012819"/>
+      <edge about="#e48" id="e48" source="n51" target="n54" length="0.1390879987"/>
+      <edge about="#e49" id="e49" source="n51" target="n55" length="0.1390879987"/>
+    </tree>
+  </trees>
+</nex:nexml>

--- a/tests/testthat/test_ape.R
+++ b/tests/testthat/test_ape.R
@@ -82,3 +82,15 @@ test_that("We can convert trees with only some edge lengths into ape::phylo", {
           # We can parse it, goodness knows what anyone will do with it.  Better to hack off the branch lengths or convert to 0, but that's for the user.   
 })
 
+
+test_that("NeXML with rootedge can be converted to ape::phylo", {
+  f <- system.file("examples", "coal.xml", package = "RNeXML")
+  nex <- read.nexml(f)
+  tr <- nex@trees[[1]]@tree[[1]]
+  phy <- as(nex, "phylo")
+  testthat::expect_equal(Nnode(phy) + Ntip(phy), length(tr@node) + 1)
+  testthat::expect_equal(Nedge(phy), length(tr@edge) + 1)
+  newick <- write.tree(phy)
+  testthat::expect_true(startsWith(newick, "(("))
+  testthat::expect_true(grepl('):[0-9.]+);$', newick))
+})

--- a/tests/testthat/test_inheritance.R
+++ b/tests/testthat/test_inheritance.R
@@ -91,3 +91,24 @@ test_that("Check that values are correct in the otus class element", {
   expect_that(otus@meta, is_a(class=c("list","ListOfmeta")))
   expect_that(otus@about, is_identical_to(character(0)))
 })
+
+test_that("Checking whether an edge is a root edge is correct", {
+  e <- nexml.edge()
+  e.xml <- as(e, "XMLInternalNode")
+  expect_is(e, "edge")
+  expect_false(is(e, "rootEdge"))
+  expect_identical(xmlName(e.xml), "edge")
+  expect_named(xmlAttrs(e.xml), expected = c("source", "target"))
+
+  e@target <- "foo"
+  e.xml <- as(e, "XMLInternalNode")
+  expect_true(is(e, "rootEdge"))
+  expect_identical(xmlName(e.xml), "rootedge")
+  expect_named(xmlAttrs(e.xml), expected = c("target"))
+
+  e@source <- "bar"
+  e.xml <- as(e, "XMLInternalNode")
+  expect_false(is(e, "rootEdge"))
+  expect_identical(xmlName(e.xml), "edge")
+  expect_named(xmlAttrs(e.xml), expected = c("source", "target"))
+})

--- a/tests/testthat/test_parsing.R
+++ b/tests/testthat/test_parsing.R
@@ -29,3 +29,23 @@ test_that("We preserve existing namespace", {
   ## Check that the new abbreviations are added 
 
 })
+
+
+test_that("files with rootedge can be parsed and roundtripped", {
+  f <- system.file("examples", "coal.xml", package = "RNeXML")
+  nex <- read.nexml(f)
+
+  tr <- nex@trees[[1]]@tree[[1]]
+  testthat::expect_true(length(tr@rootedge@target) > 0 && nchar(tr@rootedge@target) > 0)
+  testthat::expect_equal(sum(sapply(tr@node, slot, "id") == tr@rootedge@target), 1)
+  xmlOut <- as(nex, "XMLInternalNode")
+
+  nex2 <- read.nexml(xmlOut)
+  tr2 <- nex2@trees[[1]]@tree[[1]]
+  testthat::expect_true(length(tr2@rootedge@target) > 0 && nchar(tr2@rootedge@target) > 0)
+  testthat::expect_equal(sum(sapply(tr2@node, slot, "id") == tr2@rootedge@target), 1)
+  testthat::expect_equal(sum(sapply(tr2@node, slot, "id") == tr@rootedge@target), 1)
+  testthat::expect_equal(saveXML(as(tr, "XMLInternalNode")),
+                         saveXML(as(tr2, "XMLInternalNode")))
+
+})

--- a/tests/testthat/test_serializing.R
+++ b/tests/testthat/test_serializing.R
@@ -51,9 +51,12 @@ test_that("We can correctly serialize XML literals as metadata", {
   unlink("test.xml")
 })
 
-#root <- xmlRoot(xmlParse(system.file("examples", "trees.xml", package="RNeXML")))
-#tree <- as(root, "nexml")
-#tree@trees[[1]]@tree[[1]]@node[[4]]@meta
-#as(root[["trees"]][["tree"]][[4]][["meta"]], "meta")
+test_that("we can serialize NeXML with rootedge to a valid NeXML file", {
+  f <- system.file("examples", "coal.xml", package = "RNeXML")
+  nex <- read.nexml(f)
+  write.nexml(nex, file = "test.xml")
+  expect_true_or_null(nexml_validate("test.xml"))
 
+  unlink("test.xml")
+})
 


### PR DESCRIPTION
The NeXML schema provides for a `<rootedge/>` element for trees, see [AbstractRootEdge]. Although the class hierarchy here included a RootEdge class, it was not used, instantiated, or assigned in, resulting in the `<rootedge/>` element, if present, being in essence ignored and lost.

In practice, the RootEdge class is unnecessary, as a rootedge is simply an edge without a source. Since values for `source` and `target` slots are not required here (unlike in the XML schema), the `edge` class can serve for the rootedge slot, too.

The conversion to ape::phylo also ignored the rootedge slot, this is (hopefully) fixed here too.

This change includes a number of tests, though a real life test file seems hard to come by. The one included here was obtained by writing the result of `rcoal(4)` to Newick, adding a rootedge in Newick, reading it back in to ape::phylo, writing out to NeXML, and finally doctoring the XML file to convert the root edge to a `<rootedge/>` element. Apparently not even `rcoal()` will yield an actual root edge.

Closes #207.

[AbstractRootEdge]: http://www.nexml.org/doc/schema-1/trees/abstracttrees/#AbstractRootEdge