### PR TITLE
Fixes CDAO namespace definition

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -583,7 +583,7 @@ nexml_namespaces <-
   c("nex"   = "http://www.nexml.org/2009",
     "xsi"   = "http://www.w3.org/2001/XMLSchema-instance",
     "xml"   = "http://www.w3.org/XML/1998/namespace",
-    "cdao"  = "http://purl.obolibrary.org/obo/cdao.owl",
+    "cdao"  = "http://purl.obolibrary.org/obo/",
     "xsd"   = "http://www.w3.org/2001/XMLSchema#",
     "dc"    = "http://purl.org/dc/elements/1.1/",
     "dcterms" = "http://purl.org/dc/terms/",

--- a/R/classes.R
+++ b/R/classes.R
@@ -674,6 +674,13 @@ setMethod("fromNeXML",
             ns <- sapply(ns_defs, `[[`, "uri")
             obj <- add_namespaces(ns, obj)
 
+            # add our own namespaces, which will skip already present prefixes;
+            # also add a base namespace if there isn't one already
+            ourNS <- nexml_namespaces;
+            if (! any(names(obj@namespaces) == ""))
+              ourNS <- c(ourNS, unname(nexml_namespaces["nex"]))
+            obj <- add_namespaces(ourNS, nexml = obj)
+
             # Handle children
             kids <- xmlChildren(from)
             # at least 1 OTU block is required 
@@ -712,7 +719,7 @@ setAs("nexml", "XMLInternalNode",
 setAs("nexml", "XMLInternalElementNode",
       function(from) suppressWarnings(toNeXML(from, newXMLNode("nex:nexml", namespaceDefinitions = from@namespaces))))
 setAs("XMLInternalElementNode", "nexml",
-      function(from) fromNeXML(nexml(), from))
+      function(from) fromNeXML(nexml(namespaces = character(0)), from))
 
 
 

--- a/inst/examples/no-base-ns.xml
+++ b/inst/examples/no-base-ns.xml
@@ -1,3 +1,3 @@
 <nex:nexml generator="Bio::Phylo::Project v.0.58" version="0.9" xmlns:concept="http://rs.tdwg.org/ontology/voc/TaxonConcept#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:map="http://phylomap.org/terms.owl#" xmlns:nex="http://www.nexml.org/2009" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.nexml.org/2009 http://www.nexml.org/2009/nexml.xsd">
-  <nex:meta nex:content="2014-07-04T12:39:57" nex:datatype="xsd:date" nex:id="ma2052" nex:property="dc:date" xsi:type="nex:LiteralMeta"/>
+  <nex:meta nex:content="2014-07-04T12:39:57" datatype="xsd:date" id="ma2052" property="dc:date" xsi:type="nex:LiteralMeta"/>
 </nex:nexml>

--- a/inst/examples/no-base-ns.xml
+++ b/inst/examples/no-base-ns.xml
@@ -1,0 +1,3 @@
+<nex:nexml generator="Bio::Phylo::Project v.0.58" version="0.9" xmlns:concept="http://rs.tdwg.org/ontology/voc/TaxonConcept#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:map="http://phylomap.org/terms.owl#" xmlns:nex="http://www.nexml.org/2009" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.nexml.org/2009 http://www.nexml.org/2009/nexml.xsd">
+  <nex:meta nex:content="2014-07-04T12:39:57" nex:datatype="xsd:date" nex:id="ma2052" nex:property="dc:date" xsi:type="nex:LiteralMeta"/>
+</nex:nexml>

--- a/tests/testthat/test_parsing.R
+++ b/tests/testthat/test_parsing.R
@@ -14,18 +14,30 @@ test_that("We can parse a NeXML file to an S4 RNeXML::tree object", {
 
 test_that("We preserve existing namespace", {
 
-  f <- system.file("examples/biophylo.xml", package="RNeXML")
+  f <- system.file("examples", "biophylo.xml", package="RNeXML")
   nex <- nexml_read(f)
+
+  expect_gt(length(get_namespaces(nex)), length(get_namespaces(nexml())))
+  ## Check that the new abbreviations are added
+  expect_true(all(c("concept", "map") %in% names(get_namespaces(nex))))
+
   g <- tempfile()
   nexml_write(nex, g)
-
   expect_true_or_null(nexml_validate(g))
 
   nex2 <- nexml_read(g)
-
-  ## check the namespaces are added 
-  expect_gt(length(get_namespaces(nex2)), length(get_metadata(nex)))
-
+  ## check the namespaces remain there
+  expect_gt(length(get_namespaces(nex2)), length(get_namespaces(nexml())))
   ## Check that the new abbreviations are added 
+  expect_true(all(c("concept", "map") %in% names(get_namespaces(nex2))))
+  expect_equal(get_namespaces(nex2)["concept"], get_namespaces(nex)["concept"])
+  expect_equal(get_namespaces(nex2)["map"], get_namespaces(nex)["map"])
 
+  f <- system.file("examples", "phenoscape.xml", package = "RNeXML")
+  nex <- nexml_read(f)
+  # check that the cdao namespace didn't get clobbered
+  expect_true("cdao" %in% names(get_namespaces(nex)))
+  expect_equivalent(get_namespaces(nex)["cdao"],
+                    "http://www.evolutionaryontology.org/cdao/1.0/cdao.owl#")
+  expect_true(get_namespaces(nex)["cdao"] != get_namespaces(nexml())["cdao"])
 })

--- a/tests/testthat/test_parsing.R
+++ b/tests/testthat/test_parsing.R
@@ -41,3 +41,18 @@ test_that("We preserve existing namespace", {
                     "http://www.evolutionaryontology.org/cdao/1.0/cdao.owl#")
   expect_true(get_namespaces(nex)["cdao"] != get_namespaces(nexml())["cdao"])
 })
+
+test_that("base namespace gets added if not present", {
+  doc <- xmlParse(system.file("examples", "no-base-ns.xml", package="RNeXML"))
+  xmlroot <- xmlRoot(doc)
+
+  prefixes <- names(xmlNamespaceDefinitions(doc))
+  expect_false(any(prefixes == ""))
+
+  nex <- nexml_read(doc)
+  expect_true(any(names(get_namespaces(nex)) == ""))
+  expect_equal(expand_prefix("/nexml", get_namespaces(nex)),
+               expand_prefix("/nexml", get_namespaces(nexml())))
+  expect_equal(expand_prefix("nexml", get_namespaces(nex)),
+               expand_prefix("nex:nexml", get_namespaces(nex)))
+})


### PR DESCRIPTION
Also changes the CDAO prefix in example files that still use the old  (1.0) version of the ontology, so that it doesn't clash with the namespaces defined in `nexml_namespaces`.

In an ideal world this shouldn't matter - the namespaces defined in a NeXML file should simply take precedence. In practice the "nexml" object is initialized with a predefined list of namespaces, for which
there are good reasons (programming friendliness, for example), and when adding namespaces those with an already existing prefix get  skipped. As a result, if reading a file that defines `xmlns:cdao`
with the v1.0 URI, the resulting object will move those to the post-1.0 URI, where the terms don't exist (because post-1.0 term identifiers use OBO-style opaque identifiers). _(Note that this doesn't break reading, writing, or even only the syntactic validity of the term URIs -- they won't resolve but for RDF URIs don't have to resolve. But what's the point of all this if don't put value in faithfully retaining the full
URI identifiers of all ontology terms and properties.)_

Perhaps a better, or useful in addition, fix would be to reset the  initialized list of namespaces to an empty list when converting from XML, and then adding our custom list at the end. In that order, the 
prefix expansion that was in the NeXML file would now take precedence  over our custom list.

Thoughts? The more I think about it, the latter seems advised regardless of changing the `ciao:` prefix in data files, because otherwise there's a risk that the namespaces defined for the "nexml" object aren't the same expansions as those defined i the NeXML file that was read.