### PR TITLE
Fixes how metadata arguments are passed on to add_basic_meta

### DIFF
--- a/R/nexml_write.R
+++ b/R/nexml_write.R
@@ -64,10 +64,10 @@ nexml_write <- function(x = nexml(),
     nexml <- add_characters(characters, nexml = nexml)
   if(!is.null(meta))
     nexml <- add_meta(meta, nexml = nexml)
-  nexml <- do.call(add_basic_meta,
-                   c(list(...),
-                     # set last modification time upon writing
-                     list(pubdate = Sys.time(), nexml = nexml)))
+  argList <- list(..., nexml = nexml)
+  # set last modification time upon writing, if not set already
+  if (is.null(argList$pubdate)) argList$pubdate <- Sys.time()
+  nexml <- do.call(add_basic_meta, argList)
   
   out <- as(nexml, "XMLInternalNode")
   saveXML(out, file = file)

--- a/tests/testthat/test_serializing.R
+++ b/tests/testthat/test_serializing.R
@@ -9,12 +9,26 @@ test_that("We can serialize ape to S4 RNeXML into valid NeXML",{
 
   nexml <- as(bird.orders, "nexml") 
 
-  as(nexml, "XMLInternalNode")
+  saveXML(as(nexml, "XMLInternalNode"), file = "test.xml")
+  expect_true_or_null(nexml_validate("test.xml"))
+
   ###  Higher level API tests
   nexml_write(bird.orders, file="test.xml")
   expect_true_or_null(nexml_validate("test.xml"))
 
- ##  Clean up
+  ## also can write with providing multiple metadata (see README.Rmd)
+  expect_silent(nexml_write(bird.orders, file="test.xml",
+                            title = "My test title",
+                            description = "A description of my test",
+                            creator = "Carl Boettiger <cboettig@gmail.com>",
+                            publisher = "unpublished data",
+                            pubdate = "2012-04-01"))
+  nex <- nexml_read("test.xml")
+  metavals <- get_metadata_values(nex, props = c("dc:creator", "dcterms:modified"))
+  expect_equivalent(metavals["dc:creator"], "Carl Boettiger <cboettig@gmail.com>")
+  expect_equivalent(metavals["dcterms:modified"], "2012-04-01")
+
+  ##  Clean up
   unlink("test.xml")
 
   })


### PR DESCRIPTION
This went unnoticed but surfaced when regenerating README.md. Includes a test for it now.