### PR TITLE
Do not add `ter` namespace by default.

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -571,7 +571,6 @@ nexml_namespaces <-
     "xsd"   = "http://www.w3.org/2001/XMLSchema#",
     "dc"    = "http://purl.org/dc/elements/1.1/",
     "dcterms" = "http://purl.org/dc/terms/",
-    "ter" = "http://purl.org/dc/terms/",
     "prism" = "http://prismstandard.org/namespaces/1.2/basic/",
     "cc"    = "http://creativecommons.org/ns#",
     "ncbi"  = "http://www.ncbi.nlm.nih.gov/taxonomy#",


### PR DESCRIPTION
@hlapp following up on #154 here... I've just dropped `ter` from the default namespaces added by RNeXML (really no idea where I got that from in the first place...)

I didn't alter any of the nexml files in `inst/examples` that use `ter`.  I didn't detect `ter` being used in any of the tests, and the tests seem to be passing locally. (Compare: [GitHub search for `ter` in repo code](https://github.com/ropensci/RNeXML/search?q=ter%3A&unscoped_q=ter%3A)).  

I think this should close out #154, and then maybe we're ready to package up another release?  Need to update NEWS.md again...