### PR TITLE
Fixes detection of having to split matrix by class

### DIFF
--- a/R/add_characters.R
+++ b/R/add_characters.R
@@ -275,14 +275,13 @@ format_characters <- function(x){
 # divide a data.frame into a list of data.frames, in which each has only a unique column class
 split_by_class <- function(x){
     col.classes <- sapply(x, class)
-    if(all(sapply(col.classes, identical, col.classes[1])))
-      x <- list(x)
-    else {
+    if (any(col.classes == "numeric")) {
       ## split into numerics and non-numerics 
       cts <- unname(which(col.classes=="numeric"))
       discrete <- unname(which(col.classes!="numeric"))
       x <- list(x[cts], x[discrete])
-    }
+    } else
+      x <- list(x)
 
   x
 }


### PR DESCRIPTION
The original logic was overly complicated, and inconsistent with subsequent expectations of the code. This makes the condition test for the expectation that the code for splitting by type actually has.

Fixes #234. Note that this is partially a lie. While it does fix the bug reported there, the original code snippet now fails in a different place:
```R
nex <- rphenoscape::pk_get_ontotrace_xml(taxon = "Ictaluridae", entity = 'fin spine')
x <- nexml_write(characters = get_characters(nex))
 Error in map[2, ] : incorrect number of dimensions
```