### PR TITLE
 Makes various tests more robust, and uses symbolic address for nexml.org

### DIFF
--- a/R/nexml_validate.R
+++ b/R/nexml_validate.R
@@ -1,7 +1,7 @@
-ONLINE_VALIDATOR <- "http://162.13.187.155/nexml/phylows/validator"
-CANONICAL_SCHEMA <- "http://162.13.187.155/nexml/xsd/nexml.xsd"
-#ONLINE_VALIDATOR <- "http://www.nexml.org/nexml/phylows/validator"
-#CANONICAL_SCHEMA <- "http://www.nexml.org/2009/nexml.xsd"
+#ONLINE_VALIDATOR <- "http://162.13.187.155/nexml/phylows/validator"
+#CANONICAL_SCHEMA <- "http://162.13.187.155/nexml/xsd/nexml.xsd"
+ONLINE_VALIDATOR <- "http://www.nexml.org/nexml/phylows/validator"
+CANONICAL_SCHEMA <- "http://www.nexml.org/2009/nexml.xsd"
 
 #' validate nexml using the online validator tool
 #' @param file path to the nexml file to validate

--- a/tests/testthat/helper-RNeXML.R
+++ b/tests/testthat/helper-RNeXML.R
@@ -2,9 +2,9 @@
 expect_true_or_null <- function(o){
   val <- rlang::enquo(o)
   if(!is.null(o)){
-    expect_true(!!val)
+    testthat::expect_true(!!val)
   } else {
-    expect_null(!!val)
+    testthat::expect_null(!!val)
   }
 }
 

--- a/tests/testthat/test_characters.R
+++ b/tests/testthat/test_characters.R
@@ -75,7 +75,8 @@ test_that("we can add characters to a nexml file using a data.frame", {
 
 ## based on bug on 2014-03-12 65ae459523c529452adb699c3d5d118c0a207402 
 test_that("we can add multiple character matrices to a nexml file", {
-          skip_if_not(require(geiger))
+          skip_if_not_installed("geiger")
+          require(geiger)
           data(geospiza)
           data(primates)
           nexml <- add_characters(geospiza$dat)

--- a/tests/testthat/test_comp_analysis.R
+++ b/tests/testthat/test_comp_analysis.R
@@ -1,24 +1,25 @@
 context("Comparative analysis")
 
-has_geiger <- require(geiger)
-
 test_that("We can extract tree and trait data to run fitContinuous and fitDiscrete", {
-  skip_if_not(has_geiger)
+  skip_if_not_installed("geiger")
+
   nexml <- read.nexml(system.file("examples", "comp_analysis.xml", package="RNeXML"))
   traits <- get_characters(nexml)
   tree <- get_trees(nexml)
   expect_is(tree, "phylo")
-  cts <- fitContinuous(tree, traits[1], ncores=1)
+  cts <- geiger::fitContinuous(tree, traits[1], ncores=1)
   ## Incredibly, fitDiscrete cannot take discrete characters
   # dte <- fitDiscrete(tree, traits[2], ncores=1)
   traits[[2]] <- as.numeric(traits[[2]])
-  dte <- fitDiscrete(tree, traits[2], ncores=1)
+  dte <- geiger::fitDiscrete(tree, traits[2], ncores=1)
   
 })
 
 
 test_that("We can serialize tree and trait data for a comparative analysis", {
-  skip_if_not(has_geiger)
+  skip_if_not_installed("geiger")
+
+  require("geiger")
   data(geospiza)
   add_trees(geospiza$phy)
   nexml <- add_characters(geospiza$dat)

--- a/tests/testthat/test_global_ids.R
+++ b/tests/testthat/test_global_ids.R
@@ -2,6 +2,8 @@ context("Set global (uuid) identifiers")
 
 test_that("We can generate valid EML with uuid ids on all elements", {
 
+  skip_if_not_installed("geiger")
+
   if(require("uuid")){
     options(uuid = TRUE)
 

--- a/tests/testthat/test_meta_extract.R
+++ b/tests/testthat/test_meta_extract.R
@@ -244,23 +244,3 @@ test_that("we can parse LiteralMeta annotations with XML literals as values", {
   testthat::expect_true(all(sapply(m_xml[,"content"], XML::isXMLString)))
 })
 
-test_that("we can parse nested meta with blank nodes", {
-
-  skip_if_not(require(rdflib))
-  skip_if_not_installed("xslt")
-  skip_on_os("solaris")
-
-  f <- system.file("examples", "meta_example.xml", package="RNeXML")
-  nex <- read.nexml(f)
-  tmp <- tempfile()
-  xml2::write_xml(RNeXML::get_rdf(f), tmp)
-  triples <- rdflib::rdf_parse(tmp)
-  ## Check the blank node
-  df <- rdflib::rdf_query(triples, 
-  "SELECT ?s ?p ?o WHERE 
-   { ?s <http://purl.org/dc/elements/1.1/source> ?source .
-     ?source ?p ?o
-   }")
-  testthat::expect_equal(dim(df), c(3,3))
-})
-

--- a/tests/testthat/test_rdf.R
+++ b/tests/testthat/test_rdf.R
@@ -2,7 +2,7 @@ context("rdf")
 
 test_that("we can extract rdf-xml", {
 
-  skip_if_not(require(rdflib))
+  skip_if_not_installed("rdflib")
   skip_if_not_installed("xslt")
   skip_on_os("solaris")
   
@@ -10,16 +10,36 @@ test_that("we can extract rdf-xml", {
   tmp <- tempfile()  # so we must write the XML out first
   xml2::write_xml(rdf, tmp) 
   
-  graph <- rdf_parse(tmp)
+  graph <- rdflib::rdf_parse(tmp)
   
 
   expect_is(graph, "rdf")
   
-  rdf_free(graph)
+  rdflib::rdf_free(graph)
+})
+
+test_that("we can parse nested meta with blank nodes", {
+  
+  skip_if_not_installed("rdflib")
+  skip_if_not_installed("xslt")
+  skip_on_os("solaris")
+  
+  f <- system.file("examples", "meta_example.xml", package="RNeXML")
+  nex <- read.nexml(f)
+  tmp <- tempfile()
+  xml2::write_xml(get_rdf(f), tmp)
+  triples <- rdflib::rdf_parse(tmp)
+  ## Check the blank node
+  df <- rdflib::rdf_query(triples, 
+                          "SELECT ?s ?p ?o WHERE 
+                          { ?s <http://purl.org/dc/elements/1.1/source> ?source .
+                          ?source ?p ?o
+                          }")
+  testthat::expect_equal(dim(df), c(3,3))
 })
 
 test_that("we can perform sparql queries with rdf", {
-  skip_if_not(require(rdflib))
+  skip_if_not_installed("rdflib")
   skip_if_not_installed("xslt")
   # skip_on_travis()
   skip_on_os("solaris")
@@ -28,10 +48,10 @@ test_that("we can perform sparql queries with rdf", {
   tmp <- tempfile()  # so we must write the XML out first
   xml2::write_xml(rdf, tmp) 
   
-  graph <- rdf_parse(tmp)
+  graph <- rdflib::rdf_parse(tmp)
   
   
-  root <- rdf_query(graph, 
+  root <- rdflib::rdf_query(graph, 
                     "SELECT ?uri WHERE { 
     ?id <http://rs.tdwg.org/ontology/voc/TaxonConcept#rank> <http://rs.tdwg.org/ontology/voc/TaxonRank#Order> . 
     ?id <http://rs.tdwg.org/ontology/voc/TaxonConcept#toTaxon> ?uri    
@@ -39,6 +59,6 @@ test_that("we can perform sparql queries with rdf", {
   
   expect_is(root, "data.frame")
   
-  rdf_free(graph)
+  rdflib::rdf_free(graph)
   
 })

--- a/tests/testthat/test_taxonomy.R
+++ b/tests/testthat/test_taxonomy.R
@@ -18,6 +18,7 @@ chir_super_small <- add_trees(chiroptera_super_small)
 test_that("taxize_nexml correctly collects ncbi identifiers", {
   
   testthat::skip_on_cran()
+  testthat::skip_if_not_installed("taxadb")
   
   birds <- taxize_nexml(birds, "NCBI")
   
@@ -54,6 +55,7 @@ test_that("we can extract taxonomy data from the object", {
 test_that("taxize_nexml throws appropriate warnings", {
   
   testthat::skip_on_cran()
+  testthat::skip_if_not_installed("taxadb")
   
   
   chir1 <- drop.tip(chiroptera, tip = 1:910)


### PR DESCRIPTION
Specifically, fewer warnings and no errors when optional dependencies are not installed. Also, less reliance on optional package namespaces being attached. Finally, group all rdflib-dependent tests into the test_rdf script.

Also changes from numeric to symbolic address for nexml.org, which is used for the validator.