### PR TITLE
Fix for dplyr 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,7 +86,7 @@ Collate:
     'tbl_df.R'
     'utils.R'
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 X-schema.org-applicationCategory: Data Publication
 X-schema.org-keywords: metadata, nexml, phylogenetics, linked-data
 X-schema.org-isPartOf: https://ropensci.org

--- a/R/get_level.R
+++ b/R/get_level.R
@@ -22,9 +22,9 @@ SKIP = c("meta", "children", "member", "row", "cell", "seq", "matrix", "format",
 #' 
 #' The return object is a data frame whose columns are the attribute names of the elements
 #' specified. The column names match the attribute names except for "id" attribute, for which the column
-#' is renamed using the node itself. (Thus <otus id="os2"> would be rendered in a data.frame with column
+#' is renamed using the node itself. (Thus `<otus id="os2">` would be rendered in a data.frame with column
 #' called "otus" instead of "id"). Additional columns are
-#' added for each parent element in the path; e.g. get_level(nex, "otus/otu") would include a column
+#' added for each parent element in the path; e.g. `get_level(nex, "otus/otu")` would include a column
 #' named "otus" with the id of each otus block.  Even though the method always returns the data frame 
 #' for all matching nodes in all blocks, these ids let you see which otu values came from which 
 #' otus block.  This is identical to the function call `get_taxa()`.  

--- a/R/get_level.R
+++ b/R/get_level.R
@@ -82,7 +82,7 @@ nodelist_to_df <- function(node, element, fn, nodeId=NA){
                          n = nodelist,
                          id = mout[,"Meta"])
         if (is.null(names(nested))) nested <- as.data.frame(nested[,1])
-        out <- dplyr::bind_rows(mout, nested)
+        out <- dplyr::bind_rows(mout, unname(nested))
       }
     }
     dplyr::mutate_(out, .dots = dots) -> out

--- a/R/get_trees.R
+++ b/R/get_trees.R
@@ -84,7 +84,7 @@ setAs("nexml", "multiPhylo", function(from){
 
 #' Flatten a multiphylo object
 #' 
-#' @details NeXML has the concept of multiple <trees> nodes, each with multiple child <tree> nodes.
+#' @details NeXML has the concept of multiple `<trees>` nodes, each with multiple child `<tree>` nodes.
 #' This maps naturally to a list of multiphylo  objects.  Sometimes
 #' this hierarchy conveys important structural information, so it is not discarded by default. 
 #' Occasionally it is useful to flatten the structure though, hence this function.  Note that this

--- a/R/meta.R
+++ b/R/meta.R
@@ -186,7 +186,6 @@ setMethod("c",
 #' Concatenate ListOfmeta elements into a ListOfmeta
 #' 
 #' Concatenate ListOfmeta elements into a flat ListOfmeta
-#' @inheritParams c-meta
 #' @examples 
 #' metalist <- c(meta(content="example", property="dc:title"),
 #'               meta(content="Carl", property="dc:creator"))

--- a/man/flatten_multiphylo.Rd
+++ b/man/flatten_multiphylo.Rd
@@ -13,7 +13,7 @@ flatten_multiphylo(object)
 Flatten a multiphylo object
 }
 \details{
-NeXML has the concept of multiple <trees> nodes, each with multiple child <tree> nodes.
+NeXML has the concept of multiple \verb{<trees>} nodes, each with multiple child \verb{<tree>} nodes.
 This maps naturally to a list of multiphylo  objects.  Sometimes
 this hierarchy conveys important structural information, so it is not discarded by default.
 Occasionally it is useful to flatten the structure though, hence this function.  Note that this

--- a/man/get_level.Rd
+++ b/man/get_level.Rd
@@ -27,9 +27,9 @@ or similarly for states: \code{get_level(nex, characters/states)}.
 
 The return object is a data frame whose columns are the attribute names of the elements
 specified. The column names match the attribute names except for "id" attribute, for which the column
-is renamed using the node itself. (Thus <otus id="os2"> would be rendered in a data.frame with column
+is renamed using the node itself. (Thus \verb{<otus id="os2">} would be rendered in a data.frame with column
 called "otus" instead of "id"). Additional columns are
-added for each parent element in the path; e.g. get_level(nex, "otus/otu") would include a column
+added for each parent element in the path; e.g. \code{get_level(nex, "otus/otu")} would include a column
 named "otus" with the id of each otus block.  Even though the method always returns the data frame
 for all matching nodes in all blocks, these ids let you see which otu values came from which
 otus block.  This is identical to the function call \code{get_taxa()}.


### PR DESCRIPTION
It looks like the heuristic we use for automatically splicing inputs has changed subtly. Looks like the easiest fix is to simply unname().  This gets RNeXML passing R CMD check for dplyr 1.0.0, although obviously you'll also need some bigger changes to eliminate the use of deprecated lazyeval functions.

(While I was in here I also updated roxygen2 and fixed a couple of warnings)